### PR TITLE
Remove unused `get_body_message_by_title_from_mail` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Remove unused `get_body_message_by_title_from_mail` method
+
 ## 0.2.0 (2020-01-19)
 
 ### New Features


### PR DESCRIPTION
Usage removed at:
https://github.com/ONLYOFFICE/testing-onlyoffice/pull/2376